### PR TITLE
TailwindCSSの導入に伴い@import-normalizeを削除

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import-normalize;
 @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@700&display=swap");
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## 変更の概要

（前回のPRにはtypoがあったため、もう一度PRを作成しました。）
下記のようにCSSのリセットが重複していたため、`@import-normalize`を削除しました。
```css
@import-normalize;
@tailwind base;
```